### PR TITLE
Fix memory map

### DIFF
--- a/ARM.Musca-S1_DFP.pdsc
+++ b/ARM.Musca-S1_DFP.pdsc
@@ -67,12 +67,16 @@
       Musca-S1 is an Arm Cortex-M33 based dual-core device with TrustZone, CryptoCell, and eMRAM.
       </description>
 
-      <memory name="ROM1"  access="rxs"  start="0x10200000" size="0x00040000" default="1" startup="1"/>
-      <memory name="ROM2"  access="rxn"  start="0x00200000" size="0x00040000" default="1" startup="1" alias="ROM1"/>
-      <memory name="IROM1" access="rwxs" start="0x10000000" size="0x00200000" default="1" startup="0"/>
-      <memory name="IROM2" access="rwxn" start="0x00000000" size="0x00200000" default="1" startup="0" alias="IROM1"/>
-      <memory name="IRAM1" access="rwxs" start="0x30000000" size="0x00020000" default="1"/>
-      <memory name="IRAM2" access="rwxn" start="0x20000000" size="0x00020000" default="1" alias="IRAM1"/>
+      <memory name="CodeSRAM_NS" access="rwxn" start="0x00000000" size="0x00200000" default="1" startup="0" alias="CodeSRAM_S"/>
+      <memory name="QSPI_NS"     access="rxn"  start="0x00200000" size="0x02000000" default="1" startup="1" alias="QSPI_S"/>
+      <memory name="eMRAM_NS"    access="rwxn" start="0x0A000000" size="0x00200000" default="1" startup="0" alias="eMRAM_S"/>
+      <memory name="OTP_NS"      access="rxn"  start="0x0E000000" size="0x00000400" default="1" startup="0" alias="OTP_S"/>
+      <memory name="CodeSRAM_S"  access="rwxs" start="0x10000000" size="0x00200000" default="1" startup="0"/>
+      <memory name="QSPI_S"      access="rxs"  start="0x10200000" size="0x02000000" default="1" startup="1"/>
+      <memory name="eMRAM_S"     access="rwxs" start="0x1A000000" size="0x00200000" default="1" startup="0"/>
+      <memory name="OTP_S"       access="rxs"  start="0x1E000000" size="0x00000400" default="1" startup="0"/>
+      <memory name="SysSRAM_NS"  access="rwxn" start="0x20000000" size="0x00080000" default="1" alias="SysSRAM_S"/>
+      <memory name="SysSRAM_S"   access="rwxs" start="0x30000000" size="0x00080000" default="1"/>
 
       <debugvars configfile="Device/Debug/CM33.dbgconf">
         // Debug Authentication Variables


### PR DESCRIPTION
The primary purpose for this change set is to add the missing eMRAM and OTP regions, and fix sizes of the QSPI and system RAM regions. It also sorts regions by address and gives them meaningful names.

The second change is to set the `Pname` attribute on the `algorithm` elements. The PDSC documentation [says this attribute is mandatory](https://arm-software.github.io/CMSIS_5/Pack/html/pdsc_family_pg.html#element_algorithm) for multi-processor devices.

Note that `Pname` is also [supposed to be mandatory](https://arm-software.github.io/CMSIS_5/Pack/html/pdsc_family_pg.html#element_memory) for `memory` regions on multi-processor devices. I didn't add it to the region definitions because I'd like to discuss that. Imo, `Pname` should be optional for `memory` elements, and if not included then the region applies to all processors.

For `algorithm` it's fine to require `Pname` because that makes it clear on which processor the algo must run, and doesn't require duplicating what can be quite a few elements for each processor.